### PR TITLE
Proxmox VE 8 uses bookworm, not bullseye

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,16 +63,16 @@ mv /etc/apt/sources.list.d/pve-enterprise.list /etc/apt/sources.list.d/pve-enter
 
 3.Add follows into `/etc/apt/sources.list`
 ```
-deb https://mirrors.ustc.edu.cn/debian/ bullseye main contrib non-free
-deb https://mirrors.ustc.edu.cn/debian/ bullseye-updates main contrib non-free
-deb https://mirrors.ustc.edu.cn/debian/ bullseye-backports main contrib non-free
-deb https://mirrors.ustc.edu.cn/debian-security bullseye-security main contrib
+deb https://mirrors.ustc.edu.cn/debian bookworm main contrib non-free
+deb https://mirrors.ustc.edu.cn/debian/ bookworm-updates main contrib non-free
+deb https://mirrors.ustc.edu.cn/debian/ bookworm-backports main contrib non-free
+deb https://mirrors.ustc.edu.cn/debian-security bookworm-security main contrib
 #pve源
-deb https://mirrors.ustc.edu.cn/proxmox/debian bullseye pve-no-subscription
+deb https://mirrors.ustc.edu.cn/proxmox/debian bookworm pve-no-subscription
 #ceph源
-deb https://mirrors.ustc.edu.cn/proxmox/debian/ceph-pacific bullseye main
+deb https://mirrors.ustc.edu.cn/proxmox/debian/ceph-pacific bookworm main
 #开发源，必须
-deb https://mirrors.ustc.edu.cn/proxmox/debian/devel bullseye main
+deb https://mirrors.ustc.edu.cn/proxmox/debian/devel bookworm main
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ mv /etc/apt/sources.list.d/pve-enterprise.list /etc/apt/sources.list.d/pve-enter
 
 3.Add follows into `/etc/apt/sources.list`
 ```
-deb https://mirrors.ustc.edu.cn/debian bookworm main contrib non-free
+deb https://mirrors.ustc.edu.cn/debian/ bookworm main contrib non-free
 deb https://mirrors.ustc.edu.cn/debian/ bookworm-updates main contrib non-free
 deb https://mirrors.ustc.edu.cn/debian/ bookworm-backports main contrib non-free
 deb https://mirrors.ustc.edu.cn/debian-security bookworm-security main contrib


### PR DESCRIPTION
Update repos to use bookworm instead of bullseye